### PR TITLE
Add smoke test, fix WikiWhoRevContent

### DIFF
--- a/WhoColor/tests/test_utils.py
+++ b/WhoColor/tests/test_utils.py
@@ -1,0 +1,14 @@
+import unittest
+from WhoColor.utils import *
+
+class TestUtils(unittest.TestCase):
+    def test_wikiwho_from_page_id(self):
+        # Page ID of 'Selfie'
+        WikiWhoRevContent(page_id=38956275).get_tokens()
+
+    def test_wikiwho_from_page_title(self):
+        WikiWhoRevContent(page_title='Selfie').get_tokens()
+
+    def test_wikiwho_from_rev_id(self):
+        # First revision of 'Selfie'
+        WikiWhoRevContent(page_title='Selfie', rev_id=547645475).get_tokens()

--- a/WhoColor/utils.py
+++ b/WhoColor/utils.py
@@ -160,10 +160,10 @@ class WikiWhoRevContent(object):
         else:
             if self.page_id:
                 url_params = 'page_id/{}'.format(self.page_id)
-            elif self.page_title:
-                url_params = 'article_title/{}'.format(self.page_title)
             elif self.rev_id:
-                url_params = 'article_title/{}/{}'.format(self.page_title, self.rev_id)
+                url_params = '{}/{}'.format(self.page_title, self.rev_id)
+            elif self.page_title:
+                url_params = '{}'.format(self.page_title)
             return {'url': '{}/rev_content/{}/'.format(ww_api_url, url_params),
                     'params': {'o_rev_id': 'false', 'editor': 'true',
                                'token_id': 'false', 'out': 'true', 'in': 'true'}}


### PR DESCRIPTION
This adds basic smoke tests for WikiWhoRevContent, which should work with a page_id, or just a page_title, or a page_title along with a rev_id.

It fixes the _prepare_request method so that it works as intended for the page_title and page_title+rev_id cases. (The 'article_title/' path segment is not part of the wikiwho beta api.) 