### PR TITLE
Fix double-click for history box text selection

### DIFF
--- a/userscript/whocolor.user.js
+++ b/userscript/whocolor.user.js
@@ -36,7 +36,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// See her for some resource licenses:
+// See here for some resource licenses:
 //
 // https://commons.wikimedia.org/w/index.php?title=File:Clear_icon.svg&oldid=149014810
 // https://commons.wikimedia.org/w/index.php?title=File:Article_icon.svg&oldid=148759157
@@ -1096,6 +1096,9 @@ Wikiwho = {
 
                     // Calculate optimal history view height
                     var maxviewheight = $(window).height() - (selectionHeight + 20);
+
+                    // Stop hide animation (allows text selection via double-click)
+                    Wikiwho.seqHistBox.stop();
 
                     // Check whether selection is too big and if so, notify the user
                     if((maxviewheight < $(window).height()/5) || (maxviewheight < 150)) {


### PR DESCRIPTION
The history box footer wasn't showing up when selecting the words
with a double-click.

It's because on the first click, an animation is launched to hide
it (just a few lines below). After this 0.3s animation, there's a
call to .hide(). Then, if the double-click takes less than 0.3s,
the .hide() call is called after the .show() call.

minor: fixed a typo on the top-level comment also