### PR TITLE
add link to IP author contributions and removes "0|" prefix

### DIFF
--- a/userscript/whocolor.user.js
+++ b/userscript/whocolor.user.js
@@ -526,7 +526,8 @@ Wikiwho = {
                     revinfoline.append($('<div class="hvspacer"></div>'));
 
                     // Append author
-                    revinfoline.append($('<div class="hvrevauthor"></div>').text(Wikiwho.revisions[revisionArr[i]][3]).addClass("hvauthorid-"+Wikiwho.revisions[revisionArr[i]][2]).append($('<div class="hvspacerauth">                                   </div>')));
+                    var author_name = Wikiwho.revisions[revisionArr[i]][3].replace(/^0\|/, '');
+                    revinfoline.append($('<div class="hvrevauthor"></div>').text(author_name).addClass("hvauthorid-"+Wikiwho.revisions[revisionArr[i]][2]).append($('<div class="hvspacerauth">                                   </div>')));
 
                     // Append distance to next revision in list
                     if(i !== revisionArr.length - 1) {
@@ -1137,20 +1138,14 @@ Wikiwho = {
 
         // Add authors to list box
         for (var i = 0; i < Wikiwho.present_editors.length; i++) {
-            var author_name = Wikiwho.present_editors[i][0];
+            var author_name = Wikiwho.present_editors[i][0].replace(/^0\|/, '');
             var author_id = Wikiwho.present_editors[i][1];  // class name
             var author_score = Wikiwho.present_editors[i][2];
             // console.log(author_id, author_name, author_score);
-            var authentry;
 
-            // Anonymous authors don't have a contrib page
-            if(!author_name.startsWith('0|')) {
-                authentry = $('<li id="editor-'+author_id+'"><span class="editor-score">'+author_score.toFixed(1)+'%</span></li>').appendTo(authorListBox);
-                $('<span><a target="_blank" href="/wiki/Special:Contributions/'+author_name+'"><img src="'+ Wikiwho.wikicolorUrl + 'static/whocolor/images/UserAvatar.svg" class="wwhouserinfoicon"/></a></span>').appendTo(authentry);
-                $('<span>'+author_name+'</span>').appendTo(authentry);
-            }else{
-                authentry = $('<li id="editor-'+author_id+'"><span class="editor-score">'+author_score.toFixed(1)+'%</span><span><img src="'+ Wikiwho.wikicolorUrl + 'static/whocolor/images/UserAvatar.svg" class="wwhouserinfoicon wwhouserinfoiconhidden"/></span><span>'+author_name+'</span></li>').appendTo(authorListBox);
-            }
+            var authentry = $('<li id="editor-'+author_id+'"><span class="editor-score">'+author_score.toFixed(1)+'%</span></li>').appendTo(authorListBox);
+            $('<span><a target="_blank" href="/wiki/Special:Contributions/'+author_name+'"><img src="'+ Wikiwho.wikicolorUrl + 'static/whocolor/images/UserAvatar.svg" class="wwhouserinfoicon"/></a></span>').appendTo(authentry);
+            $('<span>'+author_name+'</span>').appendTo(authentry);
 
             // Create click handler (wrap in a closure first so the variables are passed correctly)
             (function(author_id, authentry) {

--- a/userscript/whocolor.user.js
+++ b/userscript/whocolor.user.js
@@ -1138,13 +1138,18 @@ Wikiwho = {
 
         // Add authors to list box
         for (var i = 0; i < Wikiwho.present_editors.length; i++) {
-            var author_name = Wikiwho.present_editors[i][0].replace(/^0\|/, '');
+            var author_name = Wikiwho.present_editors[i][0];
             var author_id = Wikiwho.present_editors[i][1];  // class name
             var author_score = Wikiwho.present_editors[i][2];
+            var author_is_anonymous = author_name.startsWith('0|')
             // console.log(author_id, author_name, author_score);
 
+            author_name = author_name.replace(/^0\|/, '')
+
             var authentry = $('<li id="editor-'+author_id+'"><span class="editor-score">'+author_score.toFixed(1)+'%</span></li>').appendTo(authorListBox);
-            $('<span><a target="_blank" href="/wiki/Special:Contributions/'+author_name+'"><img src="'+ Wikiwho.wikicolorUrl + 'static/whocolor/images/UserAvatar.svg" class="wwhouserinfoicon"/></a></span>').appendTo(authentry);
+            $('<span><a target="_blank" href="/wiki/Special:Contributions/'+author_name+'" '
+                    + (author_is_anonymous ? 'style="opacity: 0.3" ': '')
+                    +'><img src="'+ Wikiwho.wikicolorUrl + 'static/whocolor/images/UserAvatar.svg" class="wwhouserinfoicon"/></a></span>').appendTo(authentry);
             $('<span>'+author_name+'</span>').appendTo(authentry);
 
             // Create click handler (wrap in a closure first so the variables are passed correctly)


### PR DESCRIPTION
In the authors list sidebar, the IP/anonymous users didn't have a link to their contributions page (see screenshot below)

Also this PR removes the "0|" prefix for IP authors since it's an internal notation.

EDIT: The "0|" notation doesn't appear on the screenshot in the README of the project also

<hr/>

### Before 

![image](https://user-images.githubusercontent.com/1469823/54498508-a5b24300-4908-11e9-8df9-4a216004ad78.png)

### After 

![image](https://user-images.githubusercontent.com/1469823/54498696-a64bd900-490a-11e9-8c83-6d384ebf922d.png)


